### PR TITLE
Fix a broken link to the Piwik js file in the owncloud.org theme

### DIFF
--- a/themes/owncloud_org/layout.html
+++ b/themes/owncloud_org/layout.html
@@ -123,7 +123,7 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="https//piwik.owncloud.org/";
+    var u="https://piwik.owncloud.com/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', '4']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
https://github.com/owncloud/docs/issues/1257 reported that there was a broken reference to the Piwik URL in 2.5 desktop docs; which was as a result of the .org theme. This change fixes the broken URL.